### PR TITLE
ci: Delay jenkins pull request webhook

### DIFF
--- a/.github/workflows/jenkins-trigger.yml
+++ b/.github/workflows/jenkins-trigger.yml
@@ -1,0 +1,31 @@
+name: Jenkins Job Trigger
+on: pull_request_target
+
+jobs:
+  workflow_data:
+    runs-on: ubuntu-latest
+    name: Send Jenkins Pull Request Webhook
+    steps:
+      - name: Wait for compliance
+        uses: fountainhead/action-wait-for-check@v1.0.0
+        id: wait-for-compliance
+        with:
+          token: ${{ secrets.NCS_GITHUB_TOKEN }}
+          # Only the second part of the check name is needed (everything after the '/')
+          checkName: "Run compliance checks on patch series (PR)"
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Wait for oss history
+        uses: fountainhead/action-wait-for-check@v1.0.0
+        id: wait-for-oss
+        with:
+          token: ${{ secrets.NCS_GITHUB_TOKEN }}
+          # Only the second part of the check name is needed (everything after the '/')
+          checkName: "Check OSS history"
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Send Jenkins webhook
+        if: ${{ (steps.wait-for-compliance.outputs.conclusion == 'success') && (steps.wait-for-oss.outputs.conclusion == 'success') }}
+        uses: johannes-huther/webhook.sh@v1
+        env:
+          webhook_type: 'json-extended'
+          webhook_url: ${{ secrets.JENKINS_WEBHOOK_URL }}
+          webhook_secret: ${{ secrets.JENKINS_WEBHOOK_SECRET }}


### PR DESCRIPTION
* This action will wait for 'Check oss history' and 'Run compliance checks on patch series (PR)' actions
* When both actions succeeded the github pull request webhook will be sent to Jenkins

Signed-off-by: Sebastian Wezel <sebastian.wezel@nordicsemi.no>