### PR TITLE
No downstream test change

### DIFF
--- a/applications/serial_lte_modem/Kconfig
+++ b/applications/serial_lte_modem/Kconfig
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
+# No downstream test change
 
 source "Kconfig.zephyr"
 


### PR DESCRIPTION
Upmerging:

* sdk-mcuboot to 13767d0b72eb14ce42eb8aad1e5a133ef66afc54
* sdk-zephyr to 23cf38934c0f68861e403b22bc3dd0ce6efbfa39

test-sdk-nrf: test_upmerge_nov_23