### PR TITLE
oss-history: Backport changes from v2.8-branch

### DIFF
--- a/.github/workflows/oss-history.yml
+++ b/.github/workflows/oss-history.yml
@@ -14,7 +14,7 @@ jobs:
 
       - name: Install extra python dependencies
         run: |
-          pip3 install west
+          pip3 install --upgrade pip setuptools west
           pip3 install -r ncs/nrf/scripts/requirements-extra.txt
 
       - name: Set upsteam


### PR DESCRIPTION
This is to fix pygit2 install error during west install